### PR TITLE
make Render return a string, optimize it, add some tests and benchmarks

### DIFF
--- a/table.go
+++ b/table.go
@@ -1,6 +1,7 @@
 package termtable
 
 import (
+	"bytes"
 	"math"
 	"strings"
 )
@@ -74,40 +75,46 @@ func (t *Table) recalculate() {
 }
 
 func (t *Table) Render() string {
-	var tableStr string
+	// allocate a 1k byte buffer
+	bb := make([]byte, 0, 1024)
+	buf := bytes.NewBuffer(bb)
+
 	i := 0
 
 	if t.HasHeader {
 		if t.Options.UseSeparator {
-			tableStr += t.separatorLine() + "\n"
+			buf.WriteString(t.separatorLine())
+			buf.WriteRune('\n')
 		}
 		for j := range t.Rows[0] {
-			tableStr += t.getCell(i, j)
+			buf.WriteString(t.getCell(i, j))
 		}
 		i = 1
-		tableStr += "\n"
+		buf.WriteRune('\n')
 	}
 
 	if t.Options.UseSeparator {
-		tableStr += t.separatorLine() + "\n"
+		buf.WriteString(t.separatorLine())
+		buf.WriteRune('\n')
 	}
 
 	for i < len(t.Rows) {
 		row := t.Rows[i]
 		for j := range row {
-			tableStr += t.getCell(i, j)
+			buf.WriteString(t.getCell(i, j))
 		}
 		if i < len(t.Rows)-1 {
-			tableStr += "\n"
+			buf.WriteRune('\n')
 		}
 		i++
 	}
 
 	if t.Options.UseSeparator {
-		tableStr += "\n" + t.separatorLine()
+		buf.WriteRune('\n')
+		buf.WriteString(t.separatorLine())
 	}
 
-	return tableStr
+	return buf.String()
 }
 
 func (t *Table) separatorLine() string {

--- a/table_test.go
+++ b/table_test.go
@@ -15,3 +15,80 @@ func TestTermtable(t *testing.T) {
 		t.Fatalf("Got unexpected result")
 	}
 }
+
+func (t *Table) OldRender() string {
+	var tableStr string
+	i := 0
+
+	if t.HasHeader {
+		if t.Options.UseSeparator {
+			tableStr += t.separatorLine() + "\n"
+		}
+		for j := range t.Rows[0] {
+			tableStr += t.getCell(i, j)
+		}
+		i = 1
+		tableStr += "\n"
+	}
+
+	if t.Options.UseSeparator {
+		tableStr += t.separatorLine() + "\n"
+	}
+
+	for i < len(t.Rows) {
+		row := t.Rows[i]
+		for j := range row {
+			tableStr += t.getCell(i, j)
+		}
+		if i < len(t.Rows)-1 {
+			tableStr += "\n"
+		}
+		i++
+	}
+
+	if t.Options.UseSeparator {
+		tableStr += "\n" + t.separatorLine()
+	}
+
+	return tableStr
+}
+
+func BenchmarkRenderBuffer(b *testing.B) {
+	b.StopTimer()
+	ta := NewTable(nil, nil)
+	ta.SetHeader([]string{"LOWERCASE", "UPPERCASE", "NUMBERS"})
+	ta.AddRow([]string{"abc", "ABCD", "12345"})
+	ta.AddRow([]string{"defg", "EFGHI", "678"})
+	ta.AddRow([]string{"hijkl", "JKL", "9000"})
+	ta.AddRow([]string{"defg", "EFGHI", "678"})
+	ta.AddRow([]string{"hijkl", "JKL", "9000"})
+	ta.AddRow([]string{"defg", "EFGHI", "678"})
+	ta.AddRow([]string{"hijkl", "JKL", "9000"})
+	ta.AddRow([]string{"defg", "EFGHI", "678"})
+	ta.AddRow([]string{"hijkl", "JKL", "9000"})
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		ta.Render()
+	}
+}
+
+func BenchmarkRenderString(b *testing.B) {
+	b.StopTimer()
+	ta := NewTable(nil, nil)
+	ta.SetHeader([]string{"LOWERCASE", "UPPERCASE", "NUMBERS"})
+	ta.AddRow([]string{"abc", "ABCD", "12345"})
+	ta.AddRow([]string{"defg", "EFGHI", "678"})
+	ta.AddRow([]string{"hijkl", "JKL", "9000"})
+	ta.AddRow([]string{"defg", "EFGHI", "678"})
+	ta.AddRow([]string{"hijkl", "JKL", "9000"})
+	ta.AddRow([]string{"defg", "EFGHI", "678"})
+	ta.AddRow([]string{"hijkl", "JKL", "9000"})
+	ta.AddRow([]string{"defg", "EFGHI", "678"})
+	ta.AddRow([]string{"hijkl", "JKL", "9000"})
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		ta.OldRender()
+	}
+}


### PR DESCRIPTION
Hi Steve,

I remembered your post on termtable on Go+ and had use for it (tabularizing sql results for a little webapp I'm writing), but I noticed that t.Render() uses Println to print to the console instead of returning a string!

That seems very inflexible, so I changed that to return a string.  In addition, I changed Render() to use a `bytes.Buffer` instead of adding strings together, because it is less allocatey and a bit faster, especially for large tables.  I added a simple test for one of the examples in the README and a benchmark to show that my changes are sensible:

```
jmoiron@sanji:~/dev/go/termtable$ go test -bench . -benchmem
PASS
BenchmarkRenderBuffer     100000         22116 ns/op        3251 B/op        174 allocs/op
BenchmarkRenderString     100000         27378 ns/op        8037 B/op        209 allocs/op
ok      _/mnt/omocha/jmoiron/dev/go/termtable   5.473s
```

This was a pretty trivial change;  a lot more could be got out of converting a lot of the internal API to (re)use []bytes in places and you could also avoid the conversion from string to []byte.

[Embrace the []byte!](http://jmoiron.net/blog/buffers-and-allocation-go-and-python/)
