### PR TITLE
Implemented dynamic rows feature #2

### DIFF
--- a/examples/simple_tables.go
+++ b/examples/simple_tables.go
@@ -37,4 +37,33 @@ func main() {
 	t.AddRow([]string{"defg", "EFGHI", "678"})
 	t.AddRow([]string{"hijkl", "JKL", "9000"})
 	fmt.Println(t.Render())
+
+	fmt.Println("\nSimple table w/ seperators, custom padding, and dynamic rows:")
+
+	t = termtable.NewTable(nil, &termtable.TableOptions{
+		Padding:      3,
+		UseSeparator: true,
+	})
+	t.SetHeader([]string{"LOWERCASE", "UPPERCASE", "NUMBERS"})
+	t.AddRow([]string{"abc", "ABCD", "12345"})
+	t.AddRow([]string{"defg", "EFGHI", "678"})
+	t.AddRow([]string{"hijkl", "JKL", "9000"})
+	fmt.Println(t.Render())
+	t.AddRow([]string{"mnop", "MNO", "479108"})
+	fmt.Println(t.RenderDynamic())
+
+	fmt.Println("\nSimple table w/ seperators, custom padding, dynamic rows, and column wrapping:")
+
+	t = termtable.NewTable(nil, &termtable.TableOptions{
+		Padding:      3,
+		UseSeparator: true,
+	})
+	t.SetHeader([]string{"LOWERCASE", "UPPERCASE", "NUMBERS"})
+	t.AddRow([]string{"abc", "ABCD", "12345"})
+	t.AddRow([]string{"defg", "EFGHI", "678"})
+	t.AddRow([]string{"hijkl", "JKL", "9000"})
+	fmt.Println(t.Render())
+	t.AddRow([]string{"mnop", "MASDADADNO", "47910987978"})
+	t.AddRow([]string{"qrstuvwxyz", "QRS", "54234"})
+	fmt.Println(t.RenderDynamic())
 }


### PR DESCRIPTION
Added the ability to render dynamic rows to an already rendered table. This functionality is exposed via a new method `RenderDynamic()` which only renders the new rows of the table to the end of the currently rendered table.

There is one trick however used in this implementation, if `UseSeparator = true` then when calling `RenderDynamic()` it will overwrite the last written line in the terminal, this is to create a seamless rendered table.
